### PR TITLE
Fix odd number of macros panic

### DIFF
--- a/session.go
+++ b/session.go
@@ -149,6 +149,10 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		// convert data to Go strings
 		data := decodeCStrings(msg.Data[1:])
 		if len(data) != 0 {
+			if len(data)%2 == 1 {
+				data = append(data, "")
+			}
+
 			// store data in a map
 			for i := 0; i < len(data); i += 2 {
 				m.macros[data[i]] = data[i+1]


### PR DESCRIPTION
This PR fixes a problem where go-milter panics when the MTA (in this case sendmail(8)) sends an odd number of macro key/value items.

> panic: runtime error: index out of range [9] with length 9
> 
>  
> 
> goroutine 49 [running]:
> github.com/emersion/go-milter.(*milterSession).Process(0xc000208000, 0xc0000b0b20, 0x0, 0xc0000b0b20, 0x0, 0x0)
>         /go/pkg/mod/github.com/emersion/go-milter@v0.3.2/session.go:154 +0x18a5
> github.com/emersion/go-milter.(*milterSession).HandleMilterCommands(0xc000208000)
>         /go/pkg/mod/github.com/emersion/go-milter@v0.3.2/session.go:238 +0xb3
> created by github.com/emersion/go-milter.(*Server).Serve
>         /go/pkg/mod/github.com/emersion/go-milter@v0.3.2/server.go:123 +0xea

As discussed on IRC, the workaround for this problem is to append an empty value to the macro collection, which is also what other milter libraries do.