### PR TITLE
feat: Implement Abort

### DIFF
--- a/client.go
+++ b/client.go
@@ -634,14 +634,22 @@ func (s *ClientSession) End() ([]ModifyAction, *Action, error) {
 	return modifyActs, act, nil
 }
 
+// Abort sends Abort to the milter.
+//
+// This is called for an unexpected end to an email outside the milters
+// control.
+func (s *ClientSession) Abort() error {
+	return writePacket(s.conn, &Message{
+		Code: byte(CodeAbort),
+	}, s.writeTimeout)
+}
+
 // Close releases resources associated with the session.
 //
 // If there a milter sequence in progress - it is aborted.
 func (s *ClientSession) Close() error {
 	if s.needAbort {
-		writePacket(s.conn, &Message{
-			Code: byte(CodeAbort),
-		}, s.writeTimeout)
+		_ = s.Abort()
 	}
 
 	if err := writePacket(s.conn, &Message{

--- a/client_test.go
+++ b/client_test.go
@@ -48,6 +48,9 @@ type MockMilter struct {
 	BodyMod  func(m *Modifier)
 	BodyErr  error
 
+	AbortMod func(m *Modifier)
+	AbortErr error
+
 	// Info collected during calls.
 	Host   string
 	Family string
@@ -125,6 +128,13 @@ func (mm *MockMilter) Body(m *Modifier) (Response, error) {
 		mm.BodyMod(m)
 	}
 	return mm.BodyResp, mm.BodyErr
+}
+
+func (mm *MockMilter) Abort(m *Modifier) error {
+	if mm.AbortMod != nil {
+		mm.AbortMod(m)
+	}
+	return mm.AbortErr
 }
 
 func TestMilterClient_UsualFlow(t *testing.T) {
@@ -267,5 +277,98 @@ func TestMilterClient_UsualFlow(t *testing.T) {
 
 	if !reflect.DeepEqual(modifyActs, expected) {
 		t.Fatalf("Wrong modify actions, got %+v", modifyActs)
+	}
+}
+
+func TestMilterClient_AbortFlow(t *testing.T) {
+	macros := make(map[string]string)
+	mm := MockMilter{
+		ConnResp: RespContinue,
+		HeloResp: RespContinue,
+		HeloMod: func(m *Modifier) {
+			macros = m.Macros
+		},
+		AbortMod: func(m *Modifier) {
+			macros = m.Macros
+		},
+	}
+	s := Server{
+		NewMilter: func() Milter {
+			return &mm
+		},
+		Actions: OptAddHeader | OptChangeHeader,
+	}
+	defer s.Close()
+	local, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go s.Serve(local)
+
+	cl := NewClientWithOptions("tcp", local.Addr().String(), ClientOptions{
+		ActionMask: OptAddHeader | OptChangeHeader | OptQuarantine,
+	})
+	defer cl.Close()
+	session, err := cl.Session()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	assertAction := func(act *Action, err error, expectCode ActionCode) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if act.Code != expectCode {
+			t.Fatal("Unexpectedcode:", act.Code)
+		}
+	}
+
+	act, err := session.Conn("host", FamilyInet, 25565, "172.0.0.1")
+	assertAction(act, err, ActContinue)
+	if mm.Host != "host" {
+		t.Fatal("Wrong host:", mm.Host)
+	}
+	if mm.Family != "tcp4" {
+		t.Fatal("Wrong family:", mm.Family)
+	}
+	if mm.Port != 25565 {
+		t.Fatal("Wrong port:", mm.Port)
+	}
+	if mm.Addr.String() != "172.0.0.1" {
+		t.Fatal("Wrong IP:", mm.Addr)
+	}
+
+	if err := session.Macros(CodeHelo, "tls_version", "very old"); err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+
+	act, err = session.Helo("helo_host")
+	assertAction(act, err, ActContinue)
+	if mm.HeloValue != "helo_host" {
+		t.Fatal("Wrong helo value:", mm.HeloValue)
+	}
+	if v, ok := macros["tls_version"]; !ok || v != "very old" {
+		t.Fatal("Wrong tls_version macro value:", v)
+	}
+
+	err = session.Abort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate macro values are preserved for the abort callback
+	if v, ok := macros["tls_version"]; !ok || v != "very old" {
+		t.Fatal("Wrong tls_version macro value: ", v)
+	}
+
+	act, err = session.Helo("repeated_helo_host")
+	assertAction(act, err, ActContinue)
+	if mm.HeloValue != "repeated_helo_host" {
+		t.Fatal("Wrong helo value:", mm.HeloValue)
+	}
+	if len(macros["tls_version"]) != 0 {
+		t.Fatal("Unexpected macro data:", macros)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -49,6 +49,11 @@ type Milter interface {
 	// Body is called at the end of each message. All changes to message's
 	// content & attributes must be done here.
 	Body(m *Modifier) (Response, error)
+
+	// Abort is called is the current message has been aborted. All message data
+	// should be reset to prior to the Helo callback. Connection data should be
+	// preserved.
+	Abort(m *Modifier) error
 }
 
 // NoOpMilter is a dummy Milter implementation that does nothing.
@@ -86,6 +91,10 @@ func (NoOpMilter) BodyChunk(chunk []byte, m *Modifier) (Response, error) {
 
 func (NoOpMilter) Body(m *Modifier) (Response, error) {
 	return RespAccept, nil
+}
+
+func (NoOpMilter) Abort(m *Modifier) error {
+	return nil
 }
 
 // Server is a milter server.

--- a/session.go
+++ b/session.go
@@ -100,11 +100,11 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 	switch Code(msg.Code) {
 	case CodeAbort:
 		// abort current message and start over
-		m.headers = nil
-		m.macros = nil
-		m.backend = m.server.NewMilter()
-		// do not send response
-		return nil, nil
+		defer func() {
+			m.headers = nil
+			m.macros = nil
+		}()
+		return nil, m.backend.Abort(newModifier(m))
 
 	case CodeBody:
 		// body chunk


### PR DESCRIPTION
Implement Milter Abort command - This contains no response as the value is ignored by the milter so no response should be expected.

Removed the creation of a new milter session when abort occurs, as this will reset implementors connection specific data too.

Closes #12 