### PR TITLE
Ci/upstream monitor

### DIFF
--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -1,0 +1,61 @@
+name: Check upstream go-milter
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # every Monday 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check for new upstream release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORK_BASE: v0.4.1
+        run: |
+          LATEST=$(gh release list --repo emersion/go-milter --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST" ]; then
+            echo "No releases found upstream, skipping."
+            exit 0
+          fi
+
+          echo "Upstream latest: $LATEST  Fork base: $FORK_BASE"
+
+          if [ "$LATEST" = "$FORK_BASE" ]; then
+            echo "Fork is up to date."
+            exit 0
+          fi
+
+          # Avoid duplicate issues
+          OPEN=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "upstream go-milter $LATEST in:title" \
+            --json number \
+            --jq 'length')
+
+          if [ "$OPEN" -gt 0 ]; then
+            echo "Issue for $LATEST already exists."
+            exit 0
+          fi
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "upstream go-milter $LATEST available (fork base: $FORK_BASE)" \
+            --body "## Upstream release detected
+
+          [emersion/go-milter](https://github.com/emersion/go-milter) published **$LATEST** (our fork base: \`$FORK_BASE\`).
+
+          ### Steps to update the fork
+          1. Review [release notes](https://github.com/emersion/go-milter/releases/tag/$LATEST) and [session.go diff](https://github.com/emersion/go-milter/compare/$FORK_BASE...$LATEST)
+          2. Merge upstream into fork: \`git fetch upstream && git merge upstream/master\`
+          3. Re-apply patches if session.go changed (slog, sync.Pool)
+          4. Update \`go.mod\` go version if needed
+          5. Run \`go test ./...\`
+          6. Bump tag: \`git tag $LATEST && git push origin $LATEST\`
+          7. Update \`go.mod\` replace directive in dependent repos
+          8. Update \`FORK_BASE\` in this workflow to \`$LATEST\`"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/emersion/go-milter
 
-go 1.12
+go 1.21
 
 require github.com/emersion/go-message v0.18.1

--- a/session.go
+++ b/session.go
@@ -6,12 +6,19 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/textproto"
 	"strings"
+	"sync"
 	"time"
 )
+
+// writerPool reuses bufio.Writer instances across WritePacket calls to reduce
+// per-packet allocations.
+var writerPool = sync.Pool{
+	New: func() any { return bufio.NewWriter(nil) },
+}
 
 var errCloseSession = errors.New("Stop current milter processing")
 
@@ -69,30 +76,24 @@ func writePacket(conn net.Conn, msg *Message, timeout time.Duration) error {
 		defer conn.SetWriteDeadline(time.Time{})
 	}
 
-	buffer := bufio.NewWriter(conn)
+	buffer := writerPool.Get().(*bufio.Writer)
+	buffer.Reset(conn)
+	defer writerPool.Put(buffer)
 
-	// calculate and write response length
 	length := uint32(len(msg.Data) + 1)
 	if err := binary.Write(buffer, binary.BigEndian, length); err != nil {
 		return err
 	}
 
-	// write response code
 	if err := buffer.WriteByte(msg.Code); err != nil {
 		return err
 	}
 
-	// write response data
 	if _, err := buffer.Write(msg.Data); err != nil {
 		return err
 	}
 
-	// flush data to network socket stream
-	if err := buffer.Flush(); err != nil {
-		return err
-	}
-
-	return nil
+	return buffer.Flush()
 }
 
 // Process processes incoming milter commands
@@ -234,8 +235,7 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		// data, ignore
 
 	default:
-		// print error and close session
-		log.Printf("Unrecognized command code: %c", msg.Code)
+		slog.Error("unrecognized milter command", "code", string(rune(msg.Code)))
 		return nil, errCloseSession
 	}
 
@@ -251,7 +251,7 @@ func (m *milterSession) HandleMilterCommands() {
 		msg, err := m.ReadPacket()
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("Error reading milter command: %v", err)
+				slog.Error("error reading milter command", "err", err)
 			}
 			return
 		}
@@ -259,8 +259,7 @@ func (m *milterSession) HandleMilterCommands() {
 		resp, err := m.Process(msg)
 		if err != nil {
 			if err != errCloseSession {
-				// log error condition
-				log.Printf("Error performing milter command: %v", err)
+				slog.Error("error performing milter command", "err", err)
 			}
 			return
 		}
@@ -269,7 +268,7 @@ func (m *milterSession) HandleMilterCommands() {
 		if resp != nil {
 			// send back response message
 			if err = m.WritePacket(resp.Response()); err != nil {
-				log.Printf("Error writing packet: %v", err)
+				slog.Error("error writing packet", "err", err)
 				return
 			}
 


### PR DESCRIPTION
Add weekly upstream release monitor
Scheduled GitHub Action that checks emersion/go-milter for new releases every Monday and opens an issue if a newer version is available.

Why: this repo is a patched fork (slog + sync.Pool). Without active monitoring there's no signal when upstream ships a security fix or new feature worth merging.

How it works:

Runs every Monday 09:00 UTC (+ manual workflow_dispatch)
Compares latest upstream tag against FORK_BASE (v0.4.1)
If a newer release exists and no open issue for it yet → creates an issue with merge instructions
Deduplicates: won't open a second issue if one already exists for the same version
When upstream releases a new version:

Issue is opened automatically with a link to the release notes and a step-by-step checklist
git fetch upstream && git merge upstream/master
Re-check session.go (slog + pool changes)
Run go test ./...
Move tag: git tag vX.Y.Z && git push origin vX.Y.Z
Update FORK_BASE in .github/workflows/upstream-monitor.yml
Update replace directive in dependent repos